### PR TITLE
Fix HC-23: Dataset index only gets one alias from a list of aliases

### DIFF
--- a/grq2/lib/dataset.py
+++ b/grq2/lib/dataset.py
@@ -99,12 +99,14 @@ def update(update_json):
     app.logger.debug("%s" % json.dumps(ret, indent=2))
 
     # update custom aliases
+    # Fixing HC-23
     if len(aliases) > 0:
         try:
+            actions = list()
+            for index_alias in aliases:
+                actions.append({"add": {"index": index, "alias": index_alias}})
             alias_ret = es.indices.update_aliases({
-                "actions" : [
-                    { "add" : { "index" : index, "alias" : aliases } }
-                ]
+                "actions": actions
             })
             #app.logger.debug("alias_ret: %s" % json.dumps(alias_ret, indent=2))
         except Exception, e:


### PR DESCRIPTION
This change should be forward compatible with new versions of ES. 
This closes #HC-32