### PR TITLE
HC-175: install flask-restx v0.2.0 to address issues with werkzeug v1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,5 @@ setup(
     install_requires=['Flask', 'gunicorn', 'eventlet', 'pymongo',
                       'elasticsearch>=1.0.0,<2.0.0', 'requests', 'pyshp',
                       'shapely>=1.5.15', 'Cython>=0.15.1', 'Cartopy>=0.13.1',
-                      # TODO: remove installation of master branch after new release of
-                      # flask-restx includes the fix referred to here:
-                      # https://github.com/python-restx/flask-restx/issues/85
-                      'flask-restx @ git+https://git@github.com/python-restx/flask-restx',
-                      #'redis', 'flask-restx>0.1.1', 'future>=0.17.1']
-                      'redis', 'future>=0.17.1']
+                      'flask-restx>=0.2.0', 'redis', 'future>=0.17.1']
 )


### PR DESCRIPTION
End-to-end test ran on NISAR dev cluster.