### PR TITLE
cleaner way to ignore SSL warnings, bump version

### DIFF
--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -3,15 +3,11 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import urllib3
-
 from elasticsearch import RequestsHttpConnection
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 
 from hysds_commons.elasticsearch_utils import ElasticsearchUtility
 from hysds.celery import app
-
-urllib3.disable_warnings()
 
 MOZART_ES = None
 GRQ_ES = None
@@ -42,6 +38,7 @@ def get_grq_es(logger=None):
                 connection_class=RequestsHttpConnection,
                 use_ssl=True,
                 verify_certs=False,
+                ssl_show_warn=False
             )
         else:
             GRQ_ES = ElasticsearchUtility(es_url, logger)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.2',
+    version='2.0.3',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch
```
es = Elasticsearch(
    ['localhost:443', 'other_host:443'],
    # turn on SSL
    use_ssl=True,
    # no verify SSL certificates
    verify_certs=False,
    # don't show warnings about ssl certs verification
    ssl_show_warn=False
)
```