### PR TITLE
HC-255: Easily enable/disable trigger rules through the API

### DIFF
--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -555,6 +555,12 @@ class UserRules(Resource):
 
         update_doc = {}
         if rule_name:
+            if len(rule_name) > 32:
+                return {
+                           "success": False,
+                           "message": "rule_name needs to be less than 32 characters",
+                           "result": None,
+                       }, 400
             update_doc['rule_name'] = rule_name
         if hysds_io:
             update_doc['workflow'] = hysds_io

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -369,7 +369,7 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 'success': True,
                 'rule': user_rule
@@ -382,7 +382,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 "success": True,
                 "rule": user_rule

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -364,7 +364,7 @@ class UserRules(Resource):
 
         if _id:
             user_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-            if user_rule.get("success", False) is False:
+            if user_rule.get("found", False) is False:
                 return {
                     'success': False,
                     'message': 'rule %s not found' % _id
@@ -528,7 +528,7 @@ class UserRules(Resource):
         # check if job_type (hysds_io) exists in elasticsearch (only if we're updating job_type)
         if hysds_io:
             job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
-            if job_type.get("success", False) is False:
+            if job_type.get("found", False) is False:
                 return {
                     'success': False,
                     'message': 'job_type not found: %s' % hysds_io
@@ -536,7 +536,7 @@ class UserRules(Resource):
 
         if _id:
             existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-            if existing_rule.get("success", False) is False:
+            if existing_rule.get("found", False) is False:
                 return {
                            'success': False,
                            'message': 'rule %s not found' % _id

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -369,7 +369,8 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule["_source"]}
+            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule.pop("_source", None)
             return {
                 'success': True,
                 'rule': user_rule
@@ -382,7 +383,8 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule["_source"]}
+            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule.pop("_source", None)
             return {
                 "success": True,
                 "rule": user_rule
@@ -505,15 +507,12 @@ class UserRules(Resource):
 
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
-        _id = None
-        _rule_name = None
-        if "id" in request_data:
-            _id = request_data.get('id')
-        elif "rule_name" in request_data:
-            _rule_name = request_data.get("rule_name")
-        else:
+        _id = request_data.get("id", None)
+        _rule_name = request_data.get("rule_name", None)
+
+        if not _id and not _rule_name:
             return {
-                "result": False,
+                "success": False,
                 "message": "Must specify id or rule_name in the request"
             }, 400
 
@@ -618,8 +617,13 @@ class UserRules(Resource):
 
     def delete(self):
         # TODO: need to add user rules and permissions
-        _id = None
-        _rule_name = None
+        _id = request.args.get("id", None)
+        _rule_name = request.args.get("rule_name", None)
+
+        if not _id and not _rule_name:
+            return {"success": False,
+                    "message": "Must specify id or rule_name in the request"
+                    }, 400
 
         if "id" in request.args:
             _id = request.args.get('id')
@@ -646,8 +650,6 @@ class UserRules(Resource):
                 'message': 'user rule deleted',
                 'rule_name': _rule_name
             }
-        else:
-            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @ns.route('/user-tags', endpoint='user-tags')

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -624,7 +624,14 @@ class UserRules(Resource):
             }
         elif "rule_name" in request.args:
             _rule_name = request.args.get("rule_name")
-            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            query = {
+                "query": {
+                    "match": {
+                        "rule_name": _rule_name
+                    }
+                }
+            }
+            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, body=query, ignore=404)
             app.logger.info('user rule %s deleted' % _rule_name)
             return {
                 'success': True,

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -360,6 +360,7 @@ class UserRules(Resource):
     def get(self):
         # TODO: add user role and permissions
         _id = request.args.get('id')
+        _rule_name = request.args.get("rule_name")
 
         if _id:
             user_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
@@ -372,6 +373,18 @@ class UserRules(Resource):
             return {
                 'success': True,
                 'rule': user_rule
+            }
+        elif _rule_name:
+            user_rule = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            if user_rule["found"] is False:
+                return {
+                    "success": False,
+                    "message": "rule {} not found".format(_rule_name)
+                }, 404
+            user_rule = {**user_rule, **user_rule["_source"]}
+            return {
+                "success": True,
+                "rule": user_rule
             }
 
         user_rules = mozart_es.query(index=USER_RULES_INDEX)
@@ -484,12 +497,16 @@ class UserRules(Resource):
 
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
-
-        _id = request_data.get('id')
-        if not _id:
+        _id = None
+        _rule_name = None
+        if "id" in request_data:
+            _id = request_data.get('id')
+        elif "rule_name" in request_data:
+            _rule_name = request_data.get("rule_name")
+        else:
             return {
-                'result': False,
-                'message': 'id not included'
+                "result": False,
+                "message": "Must specify id or rule_name in the request"
             }, 400
 
         rule_name = request_data.get('rule_name')
@@ -511,12 +528,22 @@ class UserRules(Resource):
                     'message': 'job_type not found: %s' % hysds_io
                 }, 400
 
-        existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-        if existing_rule['found'] is False:
-            return {
-                'success': False,
-                'message': 'rule %s not found' % _id
-            }, 404
+        if _id:
+            existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
+            if existing_rule['found'] is False:
+                return {
+                           'success': False,
+                           'message': 'rule %s not found' % _id
+                       }, 404
+        elif _rule_name:
+            existing_rule = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            if existing_rule['found'] is False:
+                return {
+                           'success': False,
+                           'message': 'rule %s not found' % _rule_name
+                       }, 404
+            else:
+                _id = existing_rule.get("_id")
 
         update_doc = {}
         if rule_name:
@@ -570,18 +597,29 @@ class UserRules(Resource):
 
     def delete(self):
         # TODO: need to add user rules and permissions
-        _id = request.args.get('id')
-        if not _id:
-            return {'result': False, 'message': 'id not included'}, 400
+        _id = None
+        _rule_name = None
 
-        mozart_es.delete_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-        app.logger.info('user rule %s deleted' % _id)
-
-        return {
-            'success': True,
-            'message': 'user rule deleted',
-            'id': _id
-        }
+        if "id" in request.args:
+            _id = request.args.get('id')
+            mozart_es.delete_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
+            app.logger.info('user rule %s deleted' % _id)
+            return {
+                'success': True,
+                'message': 'user rule deleted',
+                'id': _id
+            }
+        elif "rule_name" in request.args:
+            _rule_name = request.args.get("rule_name")
+            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            app.logger.info('user rule %s deleted' % _rule_name)
+            return {
+                'success': True,
+                'message': 'user rule deleted',
+                'rule_name': _rule_name
+            }
+        else:
+            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @ns.route('/user-tags', endpoint='user-tags')

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -381,16 +381,11 @@ class UserRules(Resource):
                     "success": False,
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
-            parsed_user_rules = []
-            for rule in result.get("hits").get("hits"):
-                rule_copy = rule.copy()
-                rule_temp = {**rule_copy, **rule['_source']}
-                rule_temp.pop('_source')
-                parsed_user_rules.append(rule_temp)
-
+            user_rule = result.get("hits").get("hits")[0]
+            user_rule = {**user_rule, **user_rule["_source"]}
             return {
-                'success': True,
-                'rules': parsed_user_rules
+                "success": True,
+                "rule": user_rule
             }
 
         user_rules = mozart_es.query(index=USER_RULES_INDEX)
@@ -426,6 +421,13 @@ class UserRules(Resource):
                 'success': False,
                 'message': 'All params must be supplied: (rule_name, hysds_io, job_spec, query_string, queue)',
                 'result': None,
+            }, 400
+
+        if len(rule_name) > 32:
+            return {
+                "success": False,
+                "message": "rule_name needs to be less than 32 characters",
+                "result": None,
             }, 400
 
         try:

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -528,7 +528,7 @@ class UserRules(Resource):
         # check if job_type (hysds_io) exists in elasticsearch (only if we're updating job_type)
         if hysds_io:
             job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
-            if job_type['found'] is False:
+            if job_type.get("success", False) is False:
                 return {
                     'success': False,
                     'message': 'job_type not found: %s' % hysds_io
@@ -536,20 +536,20 @@ class UserRules(Resource):
 
         if _id:
             existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-            if existing_rule['found'] is False:
+            if existing_rule.get("success", False) is False:
                 return {
                            'success': False,
                            'message': 'rule %s not found' % _id
                        }, 404
         elif _rule_name:
-            existing_rule = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
-            if existing_rule['found'] is False:
+            result = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            if result.get("hits", {}).get("total", {}).get("value", 0) == 0:
                 return {
                            'success': False,
                            'message': 'rule %s not found' % _rule_name
                        }, 404
             else:
-                _id = existing_rule.get("_id")
+                _id = result.get("hits").get("hits")[0].get("_id")
 
         update_doc = {}
         if rule_name:

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -581,7 +581,14 @@ class UserRules(Resource):
         if queue:
             update_doc['queue'] = queue
         if enabled is not None:
-            update_doc['enabled'] = enabled
+            if isinstance(enabled, str):
+                if enabled.lower() == "false":
+                    value = False
+                else:
+                    value = True
+                update_doc["enabled"] = value
+            else:
+                update_doc["enabled"] = enabled
         if tags is not None:
             if type(tags) == str:
                 tags = [tags]

--- a/grq2/services/api_v01.py
+++ b/grq2/services/api_v01.py
@@ -369,7 +369,7 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule, **user_rule['_source']}
+            user_rule = {**user_rule}
             return {
                 'success': True,
                 'rule': user_rule
@@ -382,7 +382,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule = {**user_rule}
             return {
                 "success": True,
                 "rule": user_rule

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -341,16 +341,11 @@ class UserRules(Resource):
                     "success": False,
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
-            parsed_user_rules = []
-            for rule in result.get("hits").get("hits"):
-                rule_copy = rule.copy()
-                rule_temp = {**rule_copy, **rule['_source']}
-                rule_temp.pop('_source')
-                parsed_user_rules.append(rule_temp)
-
+            user_rule = result.get("hits").get("hits")[0]
+            user_rule = {**user_rule, **user_rule["_source"]}
             return {
-                'success': True,
-                'rules': parsed_user_rules
+                "success": True,
+                "rule": user_rule
             }
 
         user_rules = mozart_es.query(index=USER_RULES_INDEX)
@@ -386,6 +381,13 @@ class UserRules(Resource):
                 'success': False,
                 'message': 'All params must be supplied: (rule_name, hysds_io, job_spec, query_string, queue)',
                 'result': None,
+            }, 400
+
+        if len(rule_name) > 32:
+            return {
+                "success": False,
+                "message": "rule_name needs to be less than 32 characters",
+                "result": None,
             }, 400
 
         try:

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -329,7 +329,8 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule["_source"]}
+            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule.pop("_source", None)
             return {
                 'success': True,
                 'rule': user_rule
@@ -342,7 +343,8 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule["_source"]}
+            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule.pop("_source", None)
             return {
                 "success": True,
                 "rule": user_rule
@@ -465,17 +467,12 @@ class UserRules(Resource):
 
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
+        _id = request_data.get("id", None)
+        _rule_name = request_data.get("rule_name", None)
 
-        request_data = request.json or request.form
-        _id = None
-        _rule_name = None
-        if "id" in request_data:
-            _id = request_data.get('id')
-        elif "rule_name" in request_data:
-            _rule_name = request_data.get("rule_name")
-        else:
+        if not _id and not _rule_name:
             return {
-                "result": False,
+                "success": False,
                 "message": "Must specify id or rule_name in the request"
             }, 400
 
@@ -580,8 +577,13 @@ class UserRules(Resource):
 
     def delete(self):
         # TODO: need to add user rules and permissions
-        _id = None
-        _rule_name = None
+        _id = request.args.get("id", None)
+        _rule_name = request.args.get("rule_name", None)
+
+        if not _id and not _rule_name:
+            return {"success": False,
+                    "message": "Must specify id or rule_name in the request"
+                    }, 400
 
         if "id" in request.args:
             _id = request.args.get('id')
@@ -608,8 +610,6 @@ class UserRules(Resource):
                 'message': 'user rule deleted',
                 'rule_name': _rule_name
             }
-        else:
-            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @ns.route('/user-tags', endpoint='user-tags')

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -517,6 +517,12 @@ class UserRules(Resource):
 
         update_doc = {}
         if rule_name:
+            if len(rule_name) > 32:
+                return {
+                           "success": False,
+                           "message": "rule_name needs to be less than 32 characters",
+                           "result": None,
+                       }, 400
             update_doc['rule_name'] = rule_name
         if hysds_io:
             update_doc['workflow'] = hysds_io

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -320,6 +320,7 @@ class UserRules(Resource):
     def get(self):
         # TODO: add user role and permissions
         _id = request.args.get('id')
+        _rule_name = request.args.get("rule_name")
 
         if _id:
             user_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
@@ -332,6 +333,18 @@ class UserRules(Resource):
             return {
                 'success': True,
                 'rule': user_rule
+            }
+        elif _rule_name:
+            user_rule = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            if user_rule["found"] is False:
+                return {
+                    "success": False,
+                    "message": "rule {} not found".format(_rule_name)
+                }, 404
+            user_rule = {**user_rule, **user_rule["_source"]}
+            return {
+                "success": True,
+                "rule": user_rule
             }
 
         user_rules = mozart_es.query(index=USER_RULES_INDEX)
@@ -445,11 +458,17 @@ class UserRules(Resource):
     def put(self):  # TODO: add user role and permissions
         request_data = request.json or request.form
 
-        _id = request_data.get('id')
-        if not _id:
+        request_data = request.json or request.form
+        _id = None
+        _rule_name = None
+        if "id" in request_data:
+            _id = request_data.get('id')
+        elif "rule_name" in request_data:
+            _rule_name = request_data.get("rule_name")
+        else:
             return {
-                'result': False,
-                'message': 'id not included'
+                "result": False,
+                "message": "Must specify id or rule_name in the request"
             }, 400
 
         rule_name = request_data.get('rule_name')
@@ -471,12 +490,22 @@ class UserRules(Resource):
                     'message': 'job_type not found: %s' % hysds_io
                 }, 400
 
-        existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-        if existing_rule['found'] is False:
-            return {
-                'success': False,
-                'message': 'rule %s not found' % _id
-            }, 404
+        if _id:
+            existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
+            if existing_rule['found'] is False:
+                return {
+                           'success': False,
+                           'message': 'rule %s not found' % _id
+                       }, 404
+        elif _rule_name:
+            existing_rule = mozart_es.search(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            if existing_rule['found'] is False:
+                return {
+                           'success': False,
+                           'message': 'rule %s not found' % _rule_name
+                       }, 404
+            else:
+                _id = existing_rule.get("_id")
 
         update_doc = {}
         if rule_name:
@@ -530,18 +559,29 @@ class UserRules(Resource):
 
     def delete(self):
         # TODO: need to add user rules and permissions
-        _id = request.args.get('id')
-        if not _id:
-            return {'result': False, 'message': 'id not included'}, 400
+        _id = None
+        _rule_name = None
 
-        mozart_es.delete_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-        app.logger.info('user rule %s deleted' % _id)
-
-        return {
-            'success': True,
-            'message': 'user rule deleted',
-            'id': _id
-        }
+        if "id" in request.args:
+            _id = request.args.get('id')
+            mozart_es.delete_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
+            app.logger.info('user rule %s deleted' % _id)
+            return {
+                'success': True,
+                'message': 'user rule deleted',
+                'id': _id
+            }
+        elif "rule_name" in request.args:
+            _rule_name = request.args.get("rule_name")
+            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            app.logger.info('user rule %s deleted' % _rule_name)
+            return {
+                'success': True,
+                'message': 'user rule deleted',
+                'rule_name': _rule_name
+            }
+        else:
+            return {'result': False, 'message': 'id or rule_name not included'}, 400
 
 
 @ns.route('/user-tags', endpoint='user-tags')

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -543,7 +543,14 @@ class UserRules(Resource):
         if queue:
             update_doc['queue'] = queue
         if enabled is not None:
-            update_doc['enabled'] = enabled
+            if isinstance(enabled, str):
+                if enabled.lower() == "false":
+                    value = False
+                else:
+                    value = True
+                update_doc["enabled"] = value
+            else:
+                update_doc["enabled"] = enabled
         if tags is not None:
             if type(tags) == str:
                 tags = [tags]

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -324,7 +324,7 @@ class UserRules(Resource):
 
         if _id:
             user_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-            if user_rule.get("success", False) is False:
+            if user_rule.get("found", False) is False:
                 return {
                     'success': False,
                     'message': 'rule %s not found' % _id
@@ -490,7 +490,7 @@ class UserRules(Resource):
         # check if job_type (hysds_io) exists in elasticsearch (only if we're updating job_type)
         if hysds_io:
             job_type = mozart_es.get_by_id(index=HYSDS_IOS_INDEX, id=hysds_io, ignore=404)
-            if job_type.get("success", False) is False:
+            if job_type.get("found", False) is False:
                 return {
                     'success': False,
                     'message': 'job_type not found: %s' % hysds_io
@@ -498,7 +498,7 @@ class UserRules(Resource):
 
         if _id:
             existing_rule = mozart_es.get_by_id(index=USER_RULES_INDEX, id=_id, ignore=404)
-            if existing_rule.get("success", False) is False:
+            if existing_rule.get("found", False) is False:
                 return {
                            'success': False,
                            'message': 'rule %s not found' % _id

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -586,7 +586,14 @@ class UserRules(Resource):
             }
         elif "rule_name" in request.args:
             _rule_name = request.args.get("rule_name")
-            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, q="rule_name:{}".format(_rule_name), ignore=404)
+            query = {
+                "query": {
+                    "match": {
+                        "rule_name": _rule_name
+                    }
+                }
+            }
+            mozart_es.es.delete_by_query(index=USER_RULES_INDEX, body=query, ignore=404)
             app.logger.info('user rule %s deleted' % _rule_name)
             return {
                 'success': True,

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -329,7 +329,7 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 'success': True,
                 'rule': user_rule
@@ -342,7 +342,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule}
+            user_rule = {**user_rule["_source"]}
             return {
                 "success": True,
                 "rule": user_rule

--- a/grq2/services/api_v02.py
+++ b/grq2/services/api_v02.py
@@ -329,7 +329,7 @@ class UserRules(Resource):
                     'success': False,
                     'message': 'rule %s not found' % _id
                 }, 404
-            user_rule = {**user_rule, **user_rule['_source']}
+            user_rule = {**user_rule}
             return {
                 'success': True,
                 'rule': user_rule
@@ -342,7 +342,7 @@ class UserRules(Resource):
                     "message": "rule {} not found".format(_rule_name)
                 }, 404
             user_rule = result.get("hits").get("hits")[0]
-            user_rule = {**user_rule, **user_rule["_source"]}
+            user_rule = {**user_rule}
             return {
                 "success": True,
                 "rule": user_rule

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.4',
+    version='2.0.5',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR updates the GET, PUT, POST, and DELETE operations for the user-rules, where we can now query by a trigger rule name as well. Also updated the POST and PUT operations to check for rule names longer than 32 characters.

See https://hysds-core.atlassian.net/browse/HC-255 for how this was tested on a local cluster.