### PR TITLE
removed logger from es connection functions

### DIFF
--- a/grq2/__init__.py
+++ b/grq2/__init__.py
@@ -90,7 +90,7 @@ CORS(app)
 app.register_error_handler(404, resource_not_found)
 
 # initializing connection to GRQ's Elasticsearch
-grq_es = get_grq_es(logger=app.logger)
+grq_es = get_grq_es()
 
 # initializing connection to Mozart's Elasticsearch
 MOZART_ES_URL = app.config['MOZART_ES_URL']

--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -13,7 +13,7 @@ MOZART_ES = None
 GRQ_ES = None
 
 
-def get_mozart_es(es_url, logger):
+def get_mozart_es(es_url, logger=None):
     global MOZART_ES
     if MOZART_ES is None:
         MOZART_ES = ElasticsearchUtility(es_url, logger)


### PR DESCRIPTION
```
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] run: ./create_user_rules_index.py
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out: Traceback (most recent call last):
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out:   File "./create_user_rules_index.py", line 14, in <module>
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out:     from grq2 import app
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out:   File "/export/home/****/sciflo/ops/grq2/grq2/__init__.py", line 97, in <module>
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out:     mozart_es = get_mozart_es(MOZART_ES_URL)
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out: TypeError: get_mozart_es() missing 1 required positional argument: 'logger'
module.common.aws_instance.mozart (remote-exec): [100.64.122.91] out:
module.common.aws_instance.mozart (remote-exec): Fatal error: run() received nonzero return code 1 while executing!
```

forgot to test when i was removing the duplicate logging in the previous PR #44 
made the `logger` argument in `get_mozart_es()` optional (default to `None`)
also removed the `app.logger` argument in `get_grq_es()`