### PR TITLE
added es_timeout for AWS ES and moved ingest_pipeline to inside block

### DIFF
--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -38,7 +38,10 @@ def get_grq_es(logger=None):
                 connection_class=RequestsHttpConnection,
                 use_ssl=True,
                 verify_certs=False,
-                ssl_show_warn=False
+                ssl_show_warn=False,
+                timeout=30,
+                max_retries=10,
+                retry_on_timeout=True,
             )
         else:
             GRQ_ES = ElasticsearchUtility(es_url, logger)

--- a/scripts/install_ingest_pipeline.py
+++ b/scripts/install_ingest_pipeline.py
@@ -11,11 +11,15 @@ ingest_file = os.path.join(current_directory, '..', 'config', 'ingest_pipeline.j
 ingest_file = os.path.abspath(ingest_file)
 ingest_file = os.path.normpath(ingest_file)
 
-with open(ingest_file) as f:
-    pipeline_settings = json.load(f)
-    print(json.dumps(pipeline_settings, indent=2))
 
-    pipeline_name = 'dataset_pipeline'
+if __name__ == '__main__':
+    # TODO: delete pipeline here with a try except
 
-    # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IngestClient
-    grq_es.es.ingest.put_pipeline(id=pipeline_name, body=pipeline_settings, ignore=400)
+    with open(ingest_file) as f:
+        pipeline_settings = json.load(f)
+        print(json.dumps(pipeline_settings, indent=2))
+
+        pipeline_name = 'dataset_pipeline'
+
+        # https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch.client.IngestClient
+        grq_es.es.ingest.put_pipeline(id=pipeline_name, body=pipeline_settings, ignore=400)


### PR DESCRIPTION
sometimes making requests to AWS ES raises this error, [Stackoverflow](https://stackoverflow.com/a/27253193) recommends adding a `timeout` and `retry` when initializing the connection to ES
```python
es = Elasticsearch(timeout=30, max_retries=10, retry_on_timeout=True)
```

```
Traceback (most recent call last):
File "/home/######/######/ops/#######/util/exec_util.py", line 22, in wrapper
status = func(*args, **kwargs)
File "/home/######/######/ops/#######/Track_Frame_Accountability/eval_track_frame.py", line 150, in evaluate
) = get_stuf_info_from_xml(input_begin_date_time, input_end_date_time)
File "/home/######/######/ops/#######/util/stuf_util.py", line 28, in get_stuf_info_from_xml
results = ancillary_es.perform_es_range_intersection_query(
File "/home/######/######/ops/pcm_commons/pcm_commons/query/pcm_utility.py", line 503, in perform_es_range_intersection_query
result = self.search(index=index, body=query, sort=sort, size=size, _source_includes=source_includes)
File "/home/######/######/ops/hysds_commons/hysds_commons/elasticsearch_utils.py", line 168, in search
raise e
File "/home/######/######/ops/hysds_commons/hysds_commons/elasticsearch_utils.py", line 155, in search
result = self.es.search(**kwargs)
File "/home/######/######/lib/python3.8/site-packages/elasticsearch/client/utils.py", line 168, in _wrapped
return func(*args, params=params, headers=headers, **kwargs)
File "/home/######/######/lib/python3.8/site-packages/elasticsearch/client/__init__.py", line 1670, in search
return self.transport.perform_request(
File "/home/######/######/lib/python3.8/site-packages/elasticsearch/transport.py", line 415, in perform_request
raise e
File "/home/######/######/lib/python3.8/site-packages/elasticsearch/transport.py", line 381, in perform_request
status, headers_response, data = connection.perform_request(
File "/home/######/######/lib/python3.8/site-packages/elasticsearch/connection/http_requests.py", line 181, in perform_request
raise ConnectionTimeout("TIMEOUT", str(e), e)
elasticsearch.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeout(HTTPSConnectionPool(host='vpce-########-#######.vpce-svc-########.us-#####-#.vpce.amazonaws.com', port=443): Read timed out. (read timeout=10))
```