### PR TITLE
HC-367: Update to latest Pallet Project versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,9 @@ setup(
     install_requires=[
         # TODO: remove this pin on click once this celery issue is resolved:
         # https://github.com/celery/celery/issues/6768
-        'click>=7.0,<8.0',
-        'flask-restx>=0.4.0',
+        # 'click>=7.0,<8.0',  # 'click>=7.0,<8.0',  # don't think we need click here because its nto used by mozart
+        'Flask>2.0.0,<3.0.0',
+        'flask-restx>=0.5.1',
         'elasticsearch>=7.0.0,<7.14.0',
         'shapely>=1.5.15',
         'Cython>=0.15.1',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Flask>2.0.0,<3.0.0',
+        'Flask>2.0.0',
         'flask-restx>=0.5.1',
         'elasticsearch>=7.0.0,<7.14.0',
         'shapely>=1.5.15',

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,15 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.14',
+    version='2.0.15',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Flask>2.0.0',
+        'Flask>=2.0.0',
         'flask-restx>=0.5.1',
-        'elasticsearch>=7.0.0,<7.14.0',
+        "elasticsearch>=7.0.0,7.14.0",
         'shapely>=1.5.15',
         'Cython>=0.15.1',
         'Cartopy>=0.13.1',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Flask>=2.0.0',
         'flask-restx>=0.5.1',
-        "elasticsearch>=7.0.0,7.14.0",
+        "elasticsearch>=7.0.0,<7.14.0",
         'shapely>=1.5.15',
         'Cython>=0.15.1',
         'Cartopy>=0.13.1',
@@ -24,6 +24,6 @@ setup(
         'pymongo',
         'requests',
         'pyshp',
-        'redis',
+        'redis'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # TODO: remove this pin on click once this celery issue is resolved:
-        # https://github.com/celery/celery/issues/6768
-        # 'click>=7.0,<8.0',  # 'click>=7.0,<8.0',  # don't think we need click here because its nto used by mozart
         'Flask>2.0.0,<3.0.0',
         'flask-restx>=0.5.1',
         'elasticsearch>=7.0.0,<7.14.0',


### PR DESCRIPTION
This PR updates Flask to 2.x. Pins were sync'd with the Flask updates made to Pele: https://github.com/hysds/pele/pull/21