### PR TITLE
HC-425 - propagate Elasticsearch errors encountered during dataset indexing in grq2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.18',
+    version='2.0.19',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
change(s):
- wrapped everything in v0.2 dataset ingest function in a `try/except`
- bumped version

related ticket: https://hysds-core.atlassian.net/browse/HC-425

related PR: https://github.com/hysds/hysds/pull/143

we will log grq2's dataset index results in the job worker:
```
[2022-08-23 20:43:43,495: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[9d9041a8-e79b-4304-959a-01758a9dfa61]: publishing 1 dataset(s) to Elasticsearch
[2022-08-23 20:43:43,501: INFO/ForkPoolWorker-1] hysds.job_worker.run_job[9d9041a8-e79b-4304-959a-01758a9dfa61]: {"success": false, "message": "Error: <class 'NameError'>:name 'fsjdkfshdkjfsdhkfjs' is not defined\nTraceback (most recent call last):\n  File \"/export/home/hysdsops/sciflo/ops/grq2/grq2/services/api_v02/datasets.py\", line 127, in post\n    print(fsjdkfshdkjfsdhkfjs)\nNameError: name 'fsjdkfshdkjfsdhkfjs' is not defined\n", "objectid": null, "index": null}

[2022-08-23 20:43:43,502: INFO/ForkPoolWorker-1] Backing off bulk_index_dataset(...) for 0.3s (requests.exceptions.HTTPError: 400 Client Error: BAD REQUEST for url: http://100.104.10.197:8878/api/v0.2/grq/dataset/index)
```