### PR TITLE
add configuration for bulk request timeout

### DIFF
--- a/config/settings.cfg.tmpl
+++ b/config/settings.cfg.tmpl
@@ -14,6 +14,9 @@ GRQ_INDEX = "grq"
 # ElasticSearch geonames index
 GEONAMES_INDEX = "geonames"
 
+# timeout value for ElasticSearch bulk requests (defaults to 10)
+BULK_REQUEST_TIMEOUT = 30
+
 # Redis URL
 REDIS_URL = "redis://{{ MOZART_REDIS_PVT_IP }}:6379/0"
 


### PR DESCRIPTION
This PR exposes the `request_timeout` parameter of the `bulk()` ES operation and sets the default to 30 seconds. The default value is 10 seconds but in the cases where the doc payload is large, the timeout can be reached:

https://stackoverflow.com/questions/38326837/set-request-timeout-in-elastic-search-for-bulk-loads 