### PR TITLE
HC-469: Python tool to install the base ES template

### DIFF
--- a/scripts/install_base_es_template.py
+++ b/scripts/install_base_es_template.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from builtins import open
+from future import standard_library
+standard_library.install_aliases()
+import os
+import sys
+import json
+
+from grq2 import grq_es
+
+
+def write_template(tmpl_file):
+    """Write template to ES."""
+
+    with open(tmpl_file) as f:
+        tmpl = json.load(f)
+
+    # https://elasticsearch-py.readthedocs.io/en/1.3.0/api.html#elasticsearch.Elasticsearch.put_template
+    grq_es.es.indices.put_template(name="index_defaults", body=tmpl, ignore=400)
+    print(f"Successfully installed template to index_defaults:\n{json.dumps(tmpl, indent=2)}")
+
+
+if __name__ == "__main__":
+
+    # get template file
+    tmpl_file = os.path.abspath(sys.argv[1])
+
+    write_template(tmpl_file)

--- a/scripts/install_base_es_template.sh
+++ b/scripts/install_base_es_template.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+export PYTHONPATH=$BASE_PATH/..:$PYTHONPATH
+
+# install ops and dev templates
+$BASE_PATH/install_base_es_template.py

--- a/scripts/install_base_es_template.sh
+++ b/scripts/install_base_es_template.sh
@@ -4,4 +4,4 @@ BASE_PATH=$(cd "${BASE_PATH}"; pwd)
 export PYTHONPATH=$BASE_PATH/..:$PYTHONPATH
 
 # install ops and dev templates
-$BASE_PATH/install_base_es_template.py
+$BASE_PATH/install_base_es_template.py $*


### PR DESCRIPTION
- Added a Python tool to install the base ES template. This allows us to properly install the template whether the cluster is configured with local GRQ or AWS ES
- This is in conjunction with the SDS CLI PR: https://github.com/sdskit/sdscli/pull/102

Verified that the default template was installed properly on GRQ:

![image](https://github.com/hysds/grq2/assets/42812746/d5cc07a4-6971-4df4-926e-dc910f53274c)
