### PR TITLE
HC-470: Batch bulk API in grq2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.22',
+    version='2.0.23',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
related ticket: https://hysds-core.atlassian.net/browse/HC-470

Opensearch/Elasticsearch imposes a 100MB limit on data size when making requests. Elasticsearch allows you to edit `http.max_content_length` in `elasticsearch.yml` and set it to a higher value but unfortunately Opensearch doesnt have that option, therefore we need to break the data into 100MB chunks and use the bulk API on each chunk

Change(s):
- splitting the data into 100mb chunks
  - use the bulk API on each chunk and keep track of the indexed docs in case we need to rollback the data
- increased `bulk_request_timeout` default to 15 seconds
- bump version