### PR TITLE
HC-487: Test out and deploy locally a Elasticsearch service in clustered mode (multi-node)

### DIFF
--- a/grq2/__init__.py
+++ b/grq2/__init__.py
@@ -14,8 +14,8 @@ from grq2.es_connection import get_grq_es, get_mozart_es
 class ReverseProxied(object):
     """
     Wrap the application in this middleware and configure the
-    front-end server to add these headers, to let you quietly bind 
-    this to a URL other than / and to an HTTP scheme that is 
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
     different than what is used locally.
 
     In nginx:
@@ -93,8 +93,7 @@ app.register_error_handler(404, resource_not_found)
 grq_es = get_grq_es()
 
 # initializing connection to Mozart's Elasticsearch
-MOZART_ES_URL = app.config['MOZART_ES_URL']
-mozart_es = get_mozart_es(MOZART_ES_URL)
+mozart_es = get_mozart_es()
 
 # services blueprints
 from grq2.services.main import mod as main_module

--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -15,8 +15,14 @@ GRQ_ES = None
 
 def get_mozart_es(es_url, logger=None):
     global MOZART_ES
+    es_cluster_mode = app.conf['ES_CLUSTER_MODE']
+
     if MOZART_ES is None:
-        MOZART_ES = ElasticsearchUtility(es_url, logger)
+        if es_cluster_mode:
+            hosts = [app.conf.JOBS_ES_URL, app.conf.GRQ_ES_URL, app.conf.METRICS_ES_URL]
+        else:
+            hosts = [app.conf.JOBS_ES_URL]
+        MOZART_ES = ElasticsearchUtility(hosts, logger)
     return MOZART_ES
 
 
@@ -28,6 +34,7 @@ def get_grq_es(logger=None):
         es_host = app.conf['GRQ_ES_HOST']
         es_url = app.conf['GRQ_ES_URL']
         region = app.conf['AWS_REGION']
+        es_cluster_mode = app.conf['ES_CLUSTER_MODE']
 
         if aws_es is True:
             aws_auth = BotoAWSRequestsAuth(aws_host=es_host, aws_region=region, aws_service='es')
@@ -44,5 +51,9 @@ def get_grq_es(logger=None):
                 retry_on_timeout=True,
             )
         else:
-            GRQ_ES = ElasticsearchUtility(es_url, logger)
+            if es_cluster_mode:
+                hosts = [app.conf.JOBS_ES_URL, app.conf.GRQ_ES_URL, app.conf.METRICS_ES_URL]
+            else:
+                hosts = [app.conf.JOBS_ES_URL]
+            GRQ_ES = ElasticsearchUtility(hosts, logger)
     return GRQ_ES

--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -13,7 +13,7 @@ MOZART_ES = None
 GRQ_ES = None
 
 
-def get_mozart_es(es_url, logger=None):
+def get_mozart_es(logger=None):
     global MOZART_ES
     es_cluster_mode = app.conf['ES_CLUSTER_MODE']
 

--- a/grq2/es_connection.py
+++ b/grq2/es_connection.py
@@ -54,6 +54,6 @@ def get_grq_es(logger=None):
             if es_cluster_mode:
                 hosts = [app.conf.JOBS_ES_URL, app.conf.GRQ_ES_URL, app.conf.METRICS_ES_URL]
             else:
-                hosts = [app.conf.JOBS_ES_URL]
+                hosts = [es_url]
             GRQ_ES = ElasticsearchUtility(hosts, logger)
     return GRQ_ES

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.0.24',
+    version='2.0.25',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- This PR adds support for operating Elasticsearch in clustered mode. The ES cluster is composed of nodes on mozart, grq, and metrics. With this PR, Elasticsearch can still be operated in a non-clustered mode.
- This addition has been tested in SWOT PCM by restoring a snapshot from operational in flight data and performing the SWOT PCM smoke test. To make sure these updates are backwards compatible, @mcayanan is currently running [a force branch on the NISAR side](https://nisar-pcm-ci.jpl.nasa.gov/job/force-branches/job/mkarim-force_branch-E2E-test/231/).