### PR TITLE
hot-fix: Pin werkzeug module to resolve 'url_quote_plus' import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
         'requests',
         'pyshp',
         'redis',
-        "werkzeug>=2.2.0",  # TODO: remove this pin after fix has been made https://stackoverflow.com/a/73105878
+        # TODO: remove this pin after fix has been made to resolve
+        #  https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls
+        "werkzeug<3.0.0",
     ]
 )


### PR DESCRIPTION
The nightlies are failing due to the following build error:

![image](https://github.com/hysds/grq2/assets/42812746/29fc85b3-63e4-4e67-8b14-7058a9a6017c)

This is due to a major werkzeug update according to https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls

The hot fix is to pin the Werkzeug module until a Flask update can be made in the future.

Testing hot fix on the swot side with https://swot-pcm-ci.jpl.nasa.gov/job/force-branches/job/pop-force_branch-E2E-test/490/