### PR TITLE
HC-597: Fixed to gracefully ignore missing geonames index

### DIFF
--- a/grq2/lib/geonames.py
+++ b/grq2/lib/geonames.py
@@ -2,11 +2,8 @@ from future import standard_library
 standard_library.install_aliases()
 
 import json
-import elasticsearch.exceptions
-import opensearchpy.exceptions
 
 from grq2 import app, grq_es
-from hysds_commons.search_utils import JitteredBackoffException
 
 def get_cities(polygon, size=5, multipolygon=False):
     """
@@ -107,17 +104,18 @@ def get_cities(polygon, size=5, multipolygon=False):
         })
     index = app.config['GEONAMES_INDEX']
     try:
-        res = grq_es.search(index=index, body=query)  # query for results
+        # ignore 404 errors to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore=[404])
         app.logger.debug("get_cities(): %s" % json.dumps(query))
+
+        # check if we got an error response (when index doesn't exist)
+        if 'error' in res:
+            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
         return results
-    except (elasticsearch.exceptions.NotFoundError,
-            opensearchpy.exceptions.NotFoundError,
-            JitteredBackoffException):
-        return None
     except Exception as e:
         raise Exception(e)
 
@@ -168,17 +166,18 @@ def get_nearest_cities(lon, lat, size=5):
 
     index = app.config['GEONAMES_INDEX']  # query for results
     try:
-        res = grq_es.search(index=index, body=query)
-        app.logger.debug("get_continents(): %s" % json.dumps(query))
+        # ignore 404 errors to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore=[404])
+        app.logger.debug("get_nearest_cities(): %s" % json.dumps(query))
+
+        # check if we got an error response (when index doesn't exist)
+        if 'error' in res:
+            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
         return results
-    except (elasticsearch.exceptions.NotFoundError,
-            opensearchpy.exceptions.NotFoundError,
-            JitteredBackoffException):
-        return None
     except Exception as e:
         raise Exception(e)
 
@@ -250,16 +249,17 @@ def get_continents(lon, lat):
 
     index = app.config['GEONAMES_INDEX']  # query for results
     try:
-        res = grq_es.search(index=index, body=query)
+        # ignore 404 errors to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore=[404])
         app.logger.debug("get_continents(): %s" % json.dumps(query))
+
+        # check if we got an error response (when index doesn't exist)
+        if 'error' in res:
+            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
         return results
-    except (elasticsearch.exceptions.NotFoundError,
-            opensearchpy.exceptions.NotFoundError,
-            JitteredBackoffException):
-        return None
     except Exception as e:
         raise e

--- a/grq2/lib/geonames.py
+++ b/grq2/lib/geonames.py
@@ -104,18 +104,14 @@ def get_cities(polygon, size=5, multipolygon=False):
         })
     index = app.config['GEONAMES_INDEX']
     try:
-        # ignore 404 errors to skip retry/backoff mechanism
-        res = grq_es.search(index=index, body=query, ignore=[404])
+        # ignore unavailable indices to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore_unavailable=True)
         app.logger.debug("get_cities(): %s" % json.dumps(query))
-
-        # check if we got an error response (when index doesn't exist)
-        if 'error' in res:
-            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
-        return results
+        return results if results else None
     except Exception as e:
         raise Exception(e)
 
@@ -166,18 +162,14 @@ def get_nearest_cities(lon, lat, size=5):
 
     index = app.config['GEONAMES_INDEX']  # query for results
     try:
-        # ignore 404 errors to skip retry/backoff mechanism
-        res = grq_es.search(index=index, body=query, ignore=[404])
+        # ignore unavailable indices to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore_unavailable=True)
         app.logger.debug("get_nearest_cities(): %s" % json.dumps(query))
-
-        # check if we got an error response (when index doesn't exist)
-        if 'error' in res:
-            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
-        return results
+        return results if results else None
     except Exception as e:
         raise Exception(e)
 
@@ -249,17 +241,13 @@ def get_continents(lon, lat):
 
     index = app.config['GEONAMES_INDEX']  # query for results
     try:
-        # ignore 404 errors to skip retry/backoff mechanism
-        res = grq_es.search(index=index, body=query, ignore=[404])
+        # ignore unavailable indices to skip retry/backoff mechanism
+        res = grq_es.search(index=index, body=query, ignore_unavailable=True)
         app.logger.debug("get_continents(): %s" % json.dumps(query))
-
-        # check if we got an error response (when index doesn't exist)
-        if 'error' in res:
-            return None
 
         results = []
         for hit in res['hits']['hits']:
             results.append(hit['_source'])
-        return results
+        return results if results else None
     except Exception as e:
         raise e

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.3.0',
+    version='2.3.1',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This fix resolves an issue found with the latest Data in Transit updates where GRQ would be doing exponential backoff when the geonames index is missing in the database. The update was made to set the `ignore_unavailable=true` flag in the search query to most efficiently  handle this use case.


**Testing**

Verified in the grq2.log that it is no longer doing exponential backoff on the JitteredException and is now gracefully ignoring it:

<img width="2527" height="502" alt="image" src="https://github.com/user-attachments/assets/b0e6a9b9-7f05-4334-a814-4b27a00ed9b8" />
