### PR TITLE
HC-606: Updates to support OpenSearch 3.x

### DIFF
--- a/scripts/copy_add_groups_metadata.py
+++ b/scripts/copy_add_groups_metadata.py
@@ -54,5 +54,5 @@ while True:
             'temperature',
         ]
         ret = es.index(
-            index=dest, doc_type=hit['_type'], id=hit['_id'], body=doc)
+            index=dest, id=hit['_id'], body=doc)
         print("indexed %s" % hit['_id'])

--- a/scripts/copy_add_new_metadata.py
+++ b/scripts/copy_add_new_metadata.py
@@ -51,5 +51,5 @@ while True:
         ]
         doc['metadata']['dimensions'] = 4
         ret = es.index(
-            index=dest, doc_type=hit['_type'], id=hit['_id'], body=doc)
+            index=dest, id=hit['_id'], body=doc)
         print("indexed %s" % hit['_id'])

--- a/scripts/copy_add_resolutions_airx3ret.py
+++ b/scripts/copy_add_resolutions_airx3ret.py
@@ -51,5 +51,5 @@ while True:
             "(12 H2O pressure layers, 1 degree, 1 degree)",
         ]
         ret = es.index(
-            index=dest, doc_type=hit['_type'], id=hit['_id'], body=doc)
+            index=dest, id=hit['_id'], body=doc)
         print("indexed %s" % hit['_id'])

--- a/scripts/copy_add_resolutions_airx3spd.py
+++ b/scripts/copy_add_resolutions_airx3spd.py
@@ -51,5 +51,5 @@ while True:
             "(7 cloud phases, 1 degree, 1 degree)",
         ]
         ret = es.index(
-            index=dest, doc_type=hit['_type'], id=hit['_id'], body=doc)
+            index=dest, id=hit['_id'], body=doc)
         print("indexed %s" % hit['_id'])

--- a/scripts/copy_index.py
+++ b/scripts/copy_index.py
@@ -58,8 +58,7 @@ def main():
             es.index(
                 index=dest,
                 id=doc_id,
-                document=doc_source,
-                doc_type=doctype
+                document=doc_source
             )
             total_docs += 1
             

--- a/scripts/copy_index.py
+++ b/scripts/copy_index.py
@@ -13,7 +13,6 @@ from grq2.lib.utils import parse_config
 # get source and destination index
 src = sys.argv[1]
 dest = sys.argv[2]
-doctype = sys.argv[3]
 
 # get connection and create destination index
 es_url = app.config['ES_URL']

--- a/scripts/copy_modify_index.py
+++ b/scripts/copy_modify_index.py
@@ -44,5 +44,5 @@ while True:
             doc['system_version'] = doc['version']
             del doc['version']
         ret = es.index(
-            index=dest, doc_type=hit['_type'], id=hit['_id'], body=doc)
+            index=dest, id=hit['_id'], body=doc)
         print("indexed %s" % hit['_id'])

--- a/scripts/copy_user_tags.py
+++ b/scripts/copy_user_tags.py
@@ -13,7 +13,6 @@ from grq2.lib.utils import parse_config
 # get source and destination index
 src = sys.argv[1]
 dest = sys.argv[2]
-doc_type = sys.argv[3]
 
 # get url
 es_url = app.config['ES_URL']

--- a/scripts/copy_user_tags.py
+++ b/scripts/copy_user_tags.py
@@ -47,8 +47,8 @@ while True:
             "doc": {"metadata": {"user_tags": user_tags}},
             "doc_as_upsert": True
         }
-        r = requests.post('{}/{}/{}/{}/_update'.format(es_url, dest,
-                                                   doc_type, hit['_id']), data=json.dumps(new_doc))
+        r = requests.post('{}/{}/_doc/{}/_update'.format(es_url, dest,
+                                                   hit['_id']), data=json.dumps(new_doc))
         result = r.json()
         if r.status_code != 200:
             app.logger.debug("Failed to update user_tags for %s. Got status code %d:\n%s" %

--- a/scripts/create_hysds_ios_index.py
+++ b/scripts/create_hysds_ios_index.py
@@ -18,4 +18,4 @@ with open(path) as f:
     body = json.load(f)
 
     # create destination index
-    mozart_es.es.indices.create(HYSDS_IOS_INDEX, body, ignore=400)
+    mozart_es.es.indices.create(index=HYSDS_IOS_INDEX, body=body, ignore=400)

--- a/scripts/create_user_rules_index.py
+++ b/scripts/create_user_rules_index.py
@@ -22,7 +22,7 @@ def create_user_rules_index():
     with open(mapping_file) as f:
         mapping = json.load(f)
 
-    mozart_es.es.indices.create(USER_RULES_INDEX, mapping)
+    mozart_es.es.indices.create(index=USER_RULES_INDEX, body=mapping)
 
 
 try:

--- a/scripts/fix_temporal_span.py
+++ b/scripts/fix_temporal_span.py
@@ -112,8 +112,8 @@ def main():
                 "doc": {"temporal_span": new_span},
                 "doc_as_upsert": True
             }
-            r = requests.post('{}/{}/{}/{}/_update'.format(es_url, src,
-                                                       hit['_type'], hit['_id']), data=json.dumps(new_doc))
+            r = requests.post('{}/{}/_doc/{}/_update'.format(es_url, src,
+                                                       hit['_id']), data=json.dumps(new_doc))
             result = r.json()
             if r.status_code != 200:
                 app.logger.debug("Failed to update user_tags for %s. Got status code %d:\n%s" %

--- a/scripts/geonames/import_ES.py
+++ b/scripts/geonames/import_ES.py
@@ -154,7 +154,7 @@ def create_geonames_mapping(es):
     mapping = {
         "mappings": MAPPING
     }
-    es.indices.create(INDEX, mapping, ignore=400)
+    es.indices.create(index=INDEX, body=mapping, ignore=400)
     print('%s index created!!' % INDEX)
 
 

--- a/scripts/migrate_s3_datasets.py
+++ b/scripts/migrate_s3_datasets.py
@@ -44,8 +44,8 @@ def migrate(index_name):
         for hit in res['hits']['hits']:
             doc = hit['_source']
             # conn.index(hit['_source'], dest, hit['_type'], hit['_id'])
-            post_request = 'http://localhost:9200/{}/{}/{}'.format(
-                dest, hit['_type'], hit['_id'])
+            post_request = 'http://localhost:9200/{}/_doc/{}'.format(
+                dest, hit['_id'])
             r = requests.post(post_request, data=json.dumps(hit['_source']))
             if r.status_code == 200:
                 print("INFO: indexed \"{}\" on \"{}\"".format(hit['_id'], dest))

--- a/scripts/rename_s3_datasets.py
+++ b/scripts/rename_s3_datasets.py
@@ -67,7 +67,7 @@ def create_index(index, doctype):
     # get connection and create index
     es_url = 'http://localhost:9200'
     es = Elasticsearch(hosts=[es_url])
-    es.indices.create(index, ignore=400)
+    es.indices.create(index=index, ignore=400)
 
 
 url_keys = ['urls', 'browse_urls']

--- a/scripts/rename_s3_datasets.py
+++ b/scripts/rename_s3_datasets.py
@@ -143,8 +143,8 @@ while (True):
 
             updated_index = updated_doc['_index'] + '_update'
             create_index(updated_index, updated_doc['_type'])
-            post_request = 'http://localhost:9200/{}/{}/{}'.format(
-                updated_index, updated_doc['_type'], updated_doc['_id'])
+            post_request = 'http://localhost:9200/{}/_doc/{}'.format(
+                updated_index, updated_doc['_id'])
             r = requests.post(
                 post_request, data=json.dumps(updated_doc['_source']))
             if r.status_code == 200 or r.status_code == 201:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'Flask<2.3.0',  # TODO: remove kluge when Flask-DebugToolbar fixes import error
         'flask-restx>=0.5.1',
         "elasticsearch>=7.0.0,<7.14.0",
-        'opensearch-py>=2.3.0,<3.0.0',
+        'opensearch-py>=2.3.0',
         'shapely>=1.5.15',
         'Cython>=0.15.1',
         'Cartopy>=0.13.1',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='grq2',
-    version='2.3.1',
+    version='2.4.0',
     long_description='GeoRegionQuery REST API using ElasticSearch backend',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This PR contains updates to support the migration to OpenSearch 3.x. Note that the changes made here are backwards compatible with OpenSearch 2.x. Specifically, this removes the deprecated `doc_type` parameter from several of the existing scripts. In addition, we have un-pinned the opensearch-py requirement.